### PR TITLE
Change django.utils.six to six

### DIFF
--- a/qr_code/views.py
+++ b/qr_code/views.py
@@ -1,13 +1,13 @@
 import base64
 import binascii
 from io import BytesIO
+from six import wraps
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.core.signing import BadSignature, Signer
 from django.http import HttpResponse
 from django.utils.decorators import available_attrs
-from django.utils.six import wraps
 from django.views.decorators.cache import cache_page
 from django.views.decorators.http import condition
 


### PR DESCRIPTION
To Support Django3
Django3 dropped support for Python2
This requires 2 modifications
1. django.utils.six - switch to six
2 . django.utils.decorators.available_attrs()  - alternate to be explored

This commit takes care of Sl#1