### PR TITLE
Fixes #31 by passing the border parameter for segno.QRCode.save

### DIFF
--- a/qr_code/qrcode/utils.py
+++ b/qr_code/qrcode/utils.py
@@ -85,7 +85,7 @@ class QRCodeOptions:
         :raises: TypeError in case an unknown argument is given.
         """
         self._size = size
-        self._border = border
+        self._border = int(border)
         if _can_be_cast_to_int(version):
             version = int(version)  # type: ignore
             if not 1 <= version <= 40:
@@ -142,7 +142,7 @@ class QRCodeOptions:
         :rtype: dict
         """
         image_format = self._image_format
-        kw = dict(kind=image_format, scale=self._size_as_int())
+        kw = dict(border=self.border, kind=image_format, scale=self._size_as_int())
         # Change the color mapping into the keywords Segno expects
         # (remove the "_color" suffix from the module names)
         kw.update({k[:-6]: v for k, v in self.color_mapping().items()})

--- a/qr_code/tests/tests.py
+++ b/qr_code/tests/tests.py
@@ -94,6 +94,10 @@ class TestQRCodeOptions(SimpleTestCase):
         options = QRCodeOptions(image_format='invalid-image-format')
         self.assertEqual(options.image_format, DEFAULT_IMAGE_FORMAT)
 
+    def test_kw_save(self):
+        options = QRCodeOptions(border=0, image_format="png", size=13)
+        self.assertDictEqual(options.kw_save(), {'border': 0, 'kind': 'png', 'scale': 13})
+
 
 class TestContactDetail(SimpleTestCase):
     def test_make_qr_code_text(self):

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -29,7 +29,7 @@ log_file_name=log.txt
     echo "--- RAM: $(free -h)"
 
     python_versions=("3.6 3.7 3.8 3.9")
-    django_versions=("2.2.17" "3.0.11" "3.1.3")
+    django_versions=("2.2.23" "3.1.11" "3.2.3")
 
     for python_version in ${python_versions[@]}
     do


### PR DESCRIPTION
- added a simple test
- also updated the django_versions based on https://www.djangoproject.com/download/#supported-versions