### PR TITLE
Replace Mapping import from collections.abc with import from collections

### DIFF
--- a/qr_code/qrcode/serve.py
+++ b/qr_code/qrcode/serve.py
@@ -1,6 +1,6 @@
 import base64
 import urllib.parse
-from collections.abc import Mapping
+from collections import Mapping
 from datetime import datetime
 from typing import Optional, Union
 


### PR DESCRIPTION
Importing `Mapping` from `collections.abc` is deprecated and will stop working in py 3.10.

It logs the following deprecation warning when running my django app in `Python 3.9.6` environment.

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```

To double check: this package is not intended to support python < 3.3, and python2?